### PR TITLE
Fix the issue template chooser config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,1 +1,10 @@
 blank_issues_enabled: false
+
+contact_links:
+  - name: Get help in the Slack channel
+    url: https://clojurians.slack.com/messages/clojure-garden
+    about: Do you have a question? The fastest way to get help is on Clojure Garden's Slack channel!
+  - name: New issue on clojure.garden
+    url: https://github.com/clojure-garden/clojure-garden/issues/new/choose
+    about: Having a problem or enhancement suggestions? Create an issue using the appropriate template.
+


### PR DESCRIPTION
## Changes proposed:

- Add a link to the Slack channel
- Add a link to the issue template selection form

## Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](../CODE_OF_CONDUCT.md)

- [x] I agree to follow this project's Code of Conduct
